### PR TITLE
Fixes day of week match overriding day of month

### DIFF
--- a/lib/src/cronparse.dart
+++ b/lib/src/cronparse.dart
@@ -98,7 +98,7 @@ class Cron {
     return minuteMatches(time) 
       && hourMatches(time)
       && monthMatches(time)
-      && (dayOfMonthMatches(time) || dayOfWeekMatches(time));
+      && (dayOfMonthMatches(time) && dayOfWeekMatches(time));
   }
 
   /// `minuteMatches` returns true if the minute field of the expression


### PR DESCRIPTION
This fixes the matches function, specifically w.r.t. matching the day.
Previously it would match to every day if either dayOfWeek or dayOfMonth was *. Having the || operator meant that any of the two containing a * would return true for a match even if the other was false, meaning one had to specify dayOfWeek and dayOfMonth in order to not match with every day. The && operator negates this by requiring both dayOfWeek and dayOfMonth to be true.
