### PR TITLE
Fixes matching a span of weekdays

### DIFF
--- a/lib/src/cronparse.dart
+++ b/lib/src/cronparse.dart
@@ -246,9 +246,11 @@ class Cron {
         for (var i = bounds[0]; i <= bounds[1]; i++) {
           if (i == time.weekday || (i == 0 && time.weekday == 7)) return true;
         }
+      }else{
+        final v = int.parse(value);
+        if (v == time.weekday || (v == 0 && time.weekday == 7)) return true;
       }
-      final v = int.parse(value);
-      if (v == time.weekday || (v == 0 && time.weekday == 7)) return true;
+      
     }
     return false;
   }


### PR DESCRIPTION
Fixes matching a span of weekdays.
Previously an error would be thrown when a span is to be matched. The problem being the function checks if the string contains a "-" and then processes it correctly. It then tries to process it again as if it is just a number, which should be in a conditional branch stating that if the string does not contain a "-".